### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 ## CH340-DKMS
-[![Build Status](https://travis-ci.org/StefanMavrodiev/ch340-dkms.svg?branch=master)](https://travis-ci.org/StefanMavrodiev/ch340-dkms)
+[![Build Status](https://travis-ci.org/OLIMEX/ch340-dkms.svg?branch=master)](https://travis-ci.org/StefanMavrodiev/ch340-dkms)
+
+**Important**:
+In kernel version 5.5, the speed handling if fixed. You can see the commit log [here](https://github.com/torvalds/linux/commit/35714565089e5e8b091c1155517b67e29118f09d#diff-27cbcff3aa65aa3cda4aef10b416dd24). Thus if you're running kernel 5.5 or later
+please use the default ch341.ko module.
 
 ### Installation
 


### PR DESCRIPTION
The speed calculation is fixed in kernel 5.5, so add note about future usage.