### PR TITLE
Make important notice clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
-## CH340-DKMS
+# CH340-DKMS
 [![Build Status](https://travis-ci.org/OLIMEX/ch340-dkms.svg?branch=master)](https://travis-ci.org/StefanMavrodiev/ch340-dkms)
 
-**Important**:
-In kernel version 5.5, the speed handling if fixed. You can see the commit log [here](https://github.com/torvalds/linux/commit/35714565089e5e8b091c1155517b67e29118f09d#diff-27cbcff3aa65aa3cda4aef10b416dd24). Thus if you're running kernel 5.5 or later
-please use the default ch341.ko module.
+## Important notice
 
-### Installation
+⚠ Only use this driver if your kernel is 5.5 or earlier. ⚠  
+The ch341 driver's line-speed handling has been fixed since 5.5 (see [here](https://github.com/torvalds/linux/commit/35714565089e5e8b091c1155517b67e29118f09d#diff-27cbcff3aa65aa3cda4aef10b416dd24)), so it should be used instead.  
+The ch341 driver is shipped in most Linux distributions so you shouldn't need to install anything.
+
+## Installation
 
 Install required packages
 ```sh
@@ -27,7 +29,7 @@ Add the following line:
 blacklist ch341
 ```
 
-### Changelog
+## Changelog
 
-#### 1.0.0 - 3 Jun 2019
+### 1.0.0 - 3 Jun 2019
 - Initial release


### PR DESCRIPTION
I thought that the README could use some clarification.
The Olimex ESP32-POE-ISO product page redirects to this repo for Linux driver installation.  
At first glance it isn't obvious that the **ch340** driver shouldn't be installed for kernels newer than 5.5 (see https://github.com/OLIMEX/ch340-dkms/issues/4).

The repo could even be archived to really emphasize on the deprecated state of this driver.